### PR TITLE
为osx terminal提供osx_set_translator_weibo_and_show.sh脚本

### DIFF
--- a/tools/osx_set_translator_weibo_and_show.sh
+++ b/tools/osx_set_translator_weibo_and_show.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TRANSLATOR_WEIBO=$1
+
+if [ -z $TRANSLATOR_WEIBO ];then
+
+    echo "Usage: $0 TRANSLATOR_WEIBO"
+    exit;
+fi
+
+SCRIPTDIR=`(cd \`dirname $0\`; pwd)`
+BASEDIR=$(dirname $SCRIPTDIR)
+DATADIR="$BASEDIR/_data"
+
+LIST=`git --work-tree "$BASEDIR" --git-dir "${BASEDIR}/.git" status -s $DATADIR | grep -e '^ M' | cut -d ' ' -f 3`
+
+for f in $LIST;do
+    absolute_file_path=$DATADIR/${f##*/}
+    echo $absolute_file_path
+    if [ -f $absolute_file_path ]; then
+        echo "SET $f Translator WEIBO to $TRANSLATOR_WEIBO"
+        sed -i '' "s/weibo: ''/weibo: $TRANSLATOR_WEIBO/g" $absolute_file_path
+        sed -i '' "/^hide: true$/d" $absolute_file_path
+    fi
+done


### PR DESCRIPTION
修改路径获取机制，readlink在osx terminal下无效
修改grep的参数，开启正则表达式选项，osx terminal下git status -s输出，第一个字符为空格
修改所有路径全部使用绝对路径
修改sed的格式，osx terminal下sed -i必须指定extension，如果不想保留备份，需设置为空


发现set_translator_weibo_and_show.sh脚本在osx的terminal下无法使用，某些命令不兼容，所以作了上述修改，已测试过